### PR TITLE
layout/fix-heading-size

### DIFF
--- a/app/routes/job-board/index.tsx
+++ b/app/routes/job-board/index.tsx
@@ -4,7 +4,7 @@ export default function JobBoardLayout() {
   return (
     <div className="grid min-h-dvh grid-cols-1 grid-rows-[auto_1fr_auto] gap-2 bg-slate-100 dark:bg-slate-900">
       <header className="flex items-center border-b bg-card px-4 py-2 md:container">
-        <h2 className="flex-1 text-2xl font-bold">
+        <h2 className="flex-1 text-xl font-bold">
           <Link to="/job-board">Remix のお仕事あります</Link>
         </h2>
         <Link


### PR DESCRIPTION
「Remixのお仕事あります」の見出しを小さくして iPhone で見やすく。