### PR TITLE
fix broken h2 notation

### DIFF
--- a/docs/remix-docs-ja/start/tutorial.md
+++ b/docs/remix-docs-ja/start/tutorial.md
@@ -264,6 +264,7 @@ const Favorite: FunctionComponent<{
 これで、リンクをクリックするか `/contacts/1` にアクセスしても... 新しいものは何も表示されないでしょう？
 
 <img class="tutorial" loading="lazy" alt="空白のメインコンテンツを持つ連絡先ルート" src="/docs-images/contacts/05.webp" />
+
 ## ネストされたルートとアウトレット
 
 Remix は React Router をベースに構築されているため、ネストされたルーティングをサポートしています。子ルートを親レイアウト内にレンダリングするには、親内に [`Outlet`][outlet-component] をレンダリングする必要があります。修正するために、`app/root.tsx` を開き、アウトレットをレンダリングしましょう。
@@ -439,6 +440,7 @@ export default function App() {
 以上です！Remix は、このデータを UI と同期させ続けます。サイドバーは次のようになります。
 
 <img class="tutorial" loading="lazy" src="/docs-images/contacts/07.webp" />
+
 ## 型推論
 
 マップ内の `contact` 型について、TypeScript が警告を出していることに気づいたかもしれません。`typeof loader` を使用してデータについて型推論を行うために、簡単な注釈を追加できます。


### PR DESCRIPTION
Hi, I'm always very grateful for your wonderful translations!


## change sets:

From 

![CleanShot 2024-09-24 at 18 25 15](https://github.com/user-attachments/assets/bcbac668-0ac4-411f-b1e1-df6b07a73d61)

to 

![CleanShot 2024-09-24 at 18 25 07](https://github.com/user-attachments/assets/6834e173-1d01-472b-a0a6-5b2dbf79b9c4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new sections in the tutorial documentation for nested routes and type inference in Remix applications.
	- Introduced guidance on rendering the `Outlet` component for nested routing.
	- Provided recommendations for managing TypeScript warnings related to type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->