### PR TITLE
fix: update edit link for documentation to use a dynamic URL

### DIFF
--- a/apps/react-router/app/routes/_root/route.component.tsx
+++ b/apps/react-router/app/routes/_root/route.component.tsx
@@ -13,8 +13,8 @@ export default function Layout({
   const rootLoaderData = useRouteLoaderData('root') as Awaited<
     ReturnType<typeof rootLoader>
   >
-
   const product = rootLoaderData.product
+  const editUrl = `https://github.com/coji/remix-docs-ja/edit/main/docs/${__PRODUCT_ID__}${pathname === '/' ? '/index' : pathname}.md`
 
   return (
     <div className="grid h-dvh grid-rows-[auto_1fr_auto] overflow-hidden lg:container">
@@ -70,7 +70,7 @@ export default function Layout({
         </div>
         <div>
           <a
-            href={`https://github.com/coji/remix-docs-ja/edit/main/docs${pathname}.md`}
+            href={editUrl}
             target="_blank"
             rel="noreferrer"
             className="underline"

--- a/apps/remix/app/routes/_root/route.component.tsx
+++ b/apps/remix/app/routes/_root/route.component.tsx
@@ -15,6 +15,7 @@ export default function Layout({
   >
 
   const product = rootLoaderData.product
+  const editUrl = `https://github.com/coji/remix-docs-ja/edit/main/docs/${__PRODUCT_ID__}${pathname === '/' ? '/index' : pathname}.md`
 
   return (
     <div className="grid h-dvh grid-rows-[auto_1fr_auto] overflow-hidden lg:container">
@@ -70,7 +71,7 @@ export default function Layout({
         </div>
         <div>
           <a
-            href={`https://github.com/coji/remix-docs-ja/edit/main/docs${pathname}.md`}
+            href={editUrl}
             target="_blank"
             rel="noreferrer"
             className="underline"


### PR DESCRIPTION
This pull request includes changes to the `Layout` component in both the `react-router` and `remix` applications to centralize the edit URL logic and improve maintainability.

Changes to `Layout` component:

* [`apps/react-router/app/routes/_root/route.component.tsx`](diffhunk://#diff-fbe40b63c81dee49f7a32e27962323086439e760e33324c802e0b429b0976fd9L16-R17): Added a new constant `editUrl` to generate the edit URL dynamically and replaced the hardcoded URL in the anchor tag with this new constant. [[1]](diffhunk://#diff-fbe40b63c81dee49f7a32e27962323086439e760e33324c802e0b429b0976fd9L16-R17) [[2]](diffhunk://#diff-fbe40b63c81dee49f7a32e27962323086439e760e33324c802e0b429b0976fd9L73-R73)
* [`apps/remix/app/routes/_root/route.component.tsx`](diffhunk://#diff-867327beef624083fcde34a66c9fc02ff57abdd81b2202ed885e4ad90e9e3d77R18): Added a new constant `editUrl` to generate the edit URL dynamically and replaced the hardcoded URL in the anchor tag with this new constant. [[1]](diffhunk://#diff-867327beef624083fcde34a66c9fc02ff57abdd81b2202ed885e4ad90e9e3d77R18) [[2]](diffhunk://#diff-867327beef624083fcde34a66c9fc02ff57abdd81b2202ed885e4ad90e9e3d77L73-R74)