### PR TITLE
Translate "shuffle" properly

### DIFF
--- a/docs/react-router-v7/upgrading/component-routes.md
+++ b/docs/react-router-v7/upgrading/component-routes.md
@@ -201,7 +201,7 @@ ReactDOM.hydrateRoot(
 
 ## 5. 色々なものの配置先を入れ替える
 
-`root.tsx` と `entry.client.tsx` の間で、いくつかのものの配置先を入れ替えしたい場合があります。
+`root.tsx` と `entry.client.tsx` の間で、いくつかのものの配置先を入れ替えたい場合があります。
 
 一般的に:
 


### PR DESCRIPTION
https://www.ldoceonline.com/jp/dictionary/english-japanese/shuffle

> 2 a) 《他》 <書類など> を移し替える
> • He shuffled the papers on his desk. 彼は机の書類を移し替えた．
> shuffle something around ＜書類など＞をあちこち引っかき回す
> 《他》 <人員・メンバーなど> を入れ替える, の配置転換をする
> shuffle somebody around ＜人＞を入れ替える
> • The coach has shuffled the team’s starting players around several times. コーチはチームの先発メンバーをたびたび入れ替えている．

https://eow.alc.co.jp/search?q=shuffle+%e6%9b%bf%e3%81%88

> 混ぜる、ごちゃ混ぜにする、移し替える、入れ替える、切り混ぜる
> leadership shuffle 指導部の再編成［入れ替え］
> quick shuffle 迅速な混合［再編成・再構成・組み替え］
> undergo a leadership shuffle〔企業などの〕経営陣を再編する［入れ替える］


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved clarity in section 5 by updating headings and descriptions to better explain swapping the placement of elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->