### PR TITLE
docs: v7ミドルウェアAPIの安定化とドキュメント更新

### DIFF
--- a/docs/react-router-v7/api/components/Form.md
+++ b/docs/react-router-v7/api/components/Form.md
@@ -18,7 +18,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## 概要
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/variables/react_router.Form.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/functions/react_router.Form.html)
 
 [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) を介してアクションにデータを送信する、プログレッシブエンハンスメントされた HTML [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) です。[`useNavigation`](../hooks/useNavigation) で保留状態をアクティブにし、基本的な HTML フォームを超える高度なユーザーインターフェースを可能にします。フォームのアクションが完了すると、ページ上のすべてのデータが自動的に再検証され、UI がデータと同期されます。
 

--- a/docs/react-router-v7/api/components/Link.md
+++ b/docs/react-router-v7/api/components/Link.md
@@ -8,7 +8,7 @@ title: Link
 
 ## 概要
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/variables/react_router.Link.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/functions/react_router.Link.html)
 
 クライアントサイドルーティングによるナビゲーションを可能にする、段階的に機能拡張された [`<a href>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) ラッパー。
 

--- a/docs/react-router-v7/api/components/NavLink.md
+++ b/docs/react-router-v7/api/components/NavLink.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/variables/react_router.NavLink.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/functions/react_router.NavLink.html)
 
 [Link](../components/Link) をラップし、アクティブおよび保留状態のスタイル設定のための追加の props を提供します。
 

--- a/docs/react-router-v7/api/data-routers/createBrowserRouter.md
+++ b/docs/react-router-v7/api/data-routers/createBrowserRouter.md
@@ -199,21 +199,21 @@ let router = createBrowserRouter(routes, {
 
 ルーターで有効にする将来のフラグ。
 
-### opts.unstable_getContext
+### opts.getContext
 
-クライアントの [`action`](../../start/data/route-object#action)、[`loader`](../../start/data/route-object#loader)、および [ミドルウェア](../../how-to/middleware) の `context` 引数として提供される [`unstable_RouterContextProvider`](../utils/RouterContextProvider) インスタンスを返す関数です。この関数は、ナビゲーションまたはフェッチャー呼び出しごとに新しい `context` インスタンスを生成するために呼び出されます。
+クライアントの [`action`](../../start/data/route-object#action)、[`loader`](../../start/data/route-object#loader)、および [ミドルウェア](../../how-to/middleware) の `context` 引数として提供される [`RouterContextProvider`](../utils/RouterContextProvider) インスタンスを返す関数です。この関数は、ナビゲーションまたはフェッチャー呼び出しごとに新しい `context` インスタンスを生成するために呼び出されます。
 
 ```tsx
 import {
-  unstable_createContext,
-  unstable_RouterContextProvider,
+  createContext,
+  RouterContextProvider,
 } from "react-router";
 
-const apiClientContext = unstable_createContext<APIClient>();
+const apiClientContext = createContext<APIClient>();
 
 function createBrowserRouter(routes, {
-  unstable_getContext() {
-    let context = new unstable_RouterContextProvider();
+  getContext() {
+    let context = new RouterContextProvider();
     context.set(apiClientContext, getApiClient());
     return context;
   }

--- a/docs/react-router-v7/api/data-routers/createHashRouter.md
+++ b/docs/react-router-v7/api/data-routers/createHashRouter.md
@@ -47,22 +47,22 @@ function createHashRouter(
 
 ルーターで有効にするFutureフラグ。
 
-### opts.unstable_getContext
+### opts.getContext
 
-クライアントの[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[ミドルウェア](../../how-to/middleware)に`context`引数として提供される[`unstable_RouterContextProvider`](../utils/RouterContextProvider)インスタンスを返す関数。
+クライアントの[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[ミドルウェア](../../how-to/middleware)に`context`引数として提供される[`RouterContextProvider`](../utils/RouterContextProvider)インスタンスを返す関数。
 この関数は、ナビゲーションまたはフェッチャー呼び出しごとに新しい`context`インスタンスを生成するために呼び出されます。
 
 ```tsx
 import {
-  unstable_createContext,
-  unstable_RouterContextProvider,
+  createContext,
+  RouterContextProvider,
 } from "react-router";
 
-const apiClientContext = unstable_createContext<APIClient>();
+const apiClientContext = createContext<APIClient>();
 
 function createBrowserRouter(routes, {
-  unstable_getContext() {
-    let context = new unstable_RouterContextProvider();
+  getContext() {
+    let context = new RouterContextProvider();
     context.set(apiClientContext, getApiClient());
     return context;
   }
@@ -71,7 +71,7 @@ function createBrowserRouter(routes, {
 
 ### opts.hydrationData
 
-サーバーレンダリング時、および自動ハイドレーションをオプトアウトする場合、`hydrationData`オプションを使用すると、サーバーレンダリングからのハイドレーションデータを渡すことができます。これは、[`StaticHandler`](https://api.reactrouter.com/v7/interfaces/react_router.StaticHandler.html)の`query`メソッドから返される[`StaticHandlerContext`](https://api.reactrouter.com/v7/interfaces/react_router.StaticHandler.html)値からのデータのサブセットであることがほとんどです。
+サーバーレンダリング時、および自動ハイドレーションをオプトアウトする場合、`hydrationData`オプションを使用すると、サーバーレンダリングからのハイドレーションデータを渡すことができます。これは、[`StaticHandler`](https://api.reactrouter.com/v7/interfaces/react_router.StaticHandler.html)の`query`メソッドから返される[`StaticHandlerContext`](https://api.reactrouter.com/v7/interfaces/react_router.StaticHandlerContext.html)値からのデータのサブセットであることがほとんどです。
 
 ```tsx
 const router = createBrowserRouter(routes, {
@@ -287,7 +287,7 @@ let router = createBrowserRouter(routes, {
 
 場合によっては、これだけでは不十分です。大規模なアプリケーションでは、すべてのルート定義を事前に提供することは非常にコストがかかる可能性があります。さらに、特定のマイクロフロントエンドまたはモジュールフェデレーションアーキテクチャでは、すべてのルート定義を事前に提供すること自体が不可能な場合もあります。
 
-ここで`patchRoutesOnNavigation`が登場します（[RFC](https://github.com/remix-run/react-router/discussions/11113)）。このAPIは、完全なルートツリーを事前に提供できず、実行時にルートツリーの一部を遅延的に「発見」する必要がある高度なユースケース向けです。この機能は、ビデオゲームが移動するにつれて「世界」を拡大するのと同様に、ユーザーがアプリ内をナビゲートするにつれてルーターがルーティングツリーを拡大するものの、ユーザーが訪れたツリーの部分のみをロードすることになるため、しばしば["Fog of War"](https://en.wikipedia.org/wiki/Fog_of_war)と呼ばれます。
+ここで`patchRoutesOnNavigation`が登場します（[RFC](https://github.com/remix-run/react-router/discussions/11113)）。このAPIは、完全なルートツリーを事前に提供できず、実行時にルートツリーの一部を遅延的に「発見」する必要がある高度なユースケース向けです。この機能は、ビデオゲームが移動するにつれて「世界」を拡大するのと同様に、ユーザーがアプリ内をナビゲートするにつれてルーターがルーティングツリーを拡大するものの、ユーザーが訪れたツリーの部分のみをロードすることになるため、しばin["Fog of War"](https://en.wikipedia.org/wiki/Fog_of_war)と呼ばれます。
 
 `patchRoutesOnNavigation`は、React Routerが`path`をマッチできない場合に常に呼び出されます。引数には、`path`、部分的な`matches`、および新しいルートをツリーの特定の場所にパッチするために呼び出すことができる`patch`関数が含まれます。このメソッドは、`GET`リクエストのナビゲーションの`loading`フェーズ中、および非`GET`リクエストのナビゲーションの`submitting`フェーズ中に実行されます。
 
@@ -486,7 +486,7 @@ let router = createBrowserRouter(routes, {
   );
   ```
 
-  ユーザーが最初にブログ投稿（例: `/blog/my-post`）にアクセスした場合、`:slug`ルートをパッチします。その後、ユーザーが新しい投稿を作成するために`/blog/new`にナビゲートした場合、`/blog/:slug`にマッチしますが、それは_正しい_マッチではありません！まだ発見されていない、よりスコアの高いルートが存在する可能性があるので、`patchRoutesOnNavigation`を呼び出す必要があります。このケースでは実際に存在します。
+  もしユーザーが最初にブログ投稿（例: `/blog/my-post`）にアクセスした場合、`:slug`ルートをパッチします。その後、ユーザーが新しい投稿を作成するために`/blog/new`にナビゲートした場合、`/blog/:slug`にマッチしますが、それは_正しい_マッチではありません！まだ発見されていない、よりスコアの高いルートが存在する可能性があるので、`patchRoutesOnNavigation`を呼び出す必要があります。このケースでは実際に存在します。
 
   したがって、React Routerが少なくとも1つのパラメータを含むパスにマッチするたびに、`patchRoutesOnNavigation`を呼び出し、最適なマッチを見つけたことを確認するために再度ルートをマッチングします。
 

--- a/docs/react-router-v7/api/data-routers/createMemoryRouter.md
+++ b/docs/react-router-v7/api/data-routers/createMemoryRouter.md
@@ -51,9 +51,9 @@ function createMemoryRouter(
 
 ルーターで有効にするFutureフラグ。
 
-### opts.unstable_getContext
+### opts.getContext
 
-クライアントの[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[middleware](../../how-to/middleware)に`context`引数として提供される[`unstable_RouterContextProvider`](../utils/RouterContextProvider)インスタンスを返す関数です。この関数は、ナビゲーションまたはフェッチャー呼び出しごとに新しい`context`インスタンスを生成するために呼び出されます。
+クライアントの[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[middleware](../../how-to/middleware)に`context`引数として提供される[`RouterContextProvider`](../utils/RouterContextProvider)インスタンスを返す関数です。この関数は、ナビゲーションまたはフェッチャー呼び出しごとに新しい`context`インスタンスを生成するために呼び出されます。
 
 ### opts.hydrationData
 

--- a/docs/react-router-v7/api/framework-conventions/react-router.config.ts.md
+++ b/docs/react-router-v7/api/framework-conventions/react-router.config.ts.md
@@ -66,7 +66,7 @@ React Routerの完全なビルドが完了した後に呼び出される関数�
 
 ```tsx filename=react-router.config.ts
 export default {
-  buildEnd: async ({ buildManifest, serverBuildPath }) => {
+  buildEnd: async ({ buildManifest, reactRouterConfig, viteConfig }) => {
     // ここにカスタムビルドロジックを記述
     console.log("ビルドが完了しました！");
   },

--- a/docs/react-router-v7/api/framework-conventions/root.tsx.md
+++ b/docs/react-router-v7/api/framework-conventions/root.tsx.md
@@ -191,7 +191,7 @@ export function Layout({
 }
 ```
 
-[route-module]: ../start/framework/route-module
+[route-module]: ../../start/framework/route-module
 [react-link]: https://react.dev/reference/react-dom/components/link
 [react-meta]: https://react.dev/reference/react-dom/components/meta
 [react-title]: https://react.dev/reference/react-dom/components/title

--- a/docs/react-router-v7/api/framework-routers/HydratedRouter.md
+++ b/docs/react-router-v7/api/framework-routers/HydratedRouter.md
@@ -30,7 +30,7 @@ function HydratedRouter(props: HydratedRouterProps)
 
 ## Props
 
-### unstable_getContext
+### getContext
 
 [`createBrowserRouter`](../data-routers/createBrowserRouter)に渡され、[`clientAction`](../../start/framework/route-module#clientAction)/[`clientLoader`](../../start/framework/route-module#clientLoader)関数で利用可能になるコンテキストオブジェクト
 

--- a/docs/react-router-v7/api/rsc/RSCHydratedRouter.md
+++ b/docs/react-router-v7/api/rsc/RSCHydratedRouter.md
@@ -63,7 +63,7 @@ function RSCHydratedRouter({
   fetch: fetchImplementation = fetch,
   payload,
   routeDiscovery = "eager",
-  unstable_getContext,
+  getContext,
 }: RSCHydratedRouterProps)
 ```
 
@@ -77,9 +77,9 @@ function RSCHydratedRouter({
 
 オプションのfetch実装です。デフォルトはグローバルの[`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch)です。
 
-### unstable_getContext
+### getContext
 
-[`unstable_RouterContextProvider`](../utils/RouterContextProvider)インスタンスを返す関数です。これは、クライアントの[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[middleware](../../how-to/middleware)に`context`引数として提供されます。この関数は、ナビゲーションまたはフェッチャー呼び出しごとに新しい`context`インスタンスを生成するために呼び出されます。
+[`RouterContextProvider`](../utils/RouterContextProvider)インスタンスを返す関数です。これは、クライアントの[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[middleware](../../how-to/middleware)に`context`引数として提供されます。この関数は、ナビゲーションまたはフェッチャー呼び出しごとに新しい`context`インスタンスを生成するために呼び出されます。
 
 ### payload
 

--- a/docs/react-router-v7/api/rsc/matchRSCServerRequest.md
+++ b/docs/react-router-v7/api/rsc/matchRSCServerRequest.md
@@ -81,7 +81,7 @@ async function matchRSCServerRequest({
   decodeReply?: DecodeReplyFunction;
   decodeAction?: DecodeActionFunction;
   decodeFormState?: DecodeFormStateFunction;
-  requestContext?: unstable_RouterContextProvider;
+  requestContext?: RouterContextProvider;
   loadServerAction?: LoadServerActionFunction;
   onError?: (error: unknown) => void;
   request: Request;
@@ -137,7 +137,7 @@ IDによってサーバーアクションをロードするために使用され
 
 ### opts.requestContext
 
-リクエストごとに作成され、[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[middleware](../../how-to/middleware)に渡される[`unstable_RouterContextProvider`](../utils/RouterContextProvider)のインスタンスです。
+リクエストごとに作成され、[`action`](../../start/data/route-object#action)s、[`loader`](../../start/data/route-object#loader)s、および[middleware](../../how-to/middleware)に渡される[`RouterContextProvider`](../utils/RouterContextProvider)のインスタンスです。
 
 ### opts.routes
 

--- a/docs/react-router-v7/api/utils/RouterContextProvider.md
+++ b/docs/react-router-v7/api/utils/RouterContextProvider.md
@@ -1,9 +1,8 @@
 ---
 title: RouterContextProvider
-unstable: true
 ---
 
-# unstable_RouterContextProvider
+# RouterContextProvider
 
 <!--
 ⚠️ ⚠️ IMPORTANT ⚠️ ⚠️ 
@@ -19,25 +18,20 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 [MODES: framework, data]
 
-<br />
-<br />
-
-<docs-warning>このAPIは実験的であり、マイナー/パッチリリースで破壊的変更が行われる可能性があります。ご使用の際はご注意いただき、関連する変更についてはリリースノートに**細心の**注意を払ってください。</docs-warning>
-
 ## 概要
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/classes/react_router.unstable_RouterContextProvider.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/classes/react_router.RouterContextProvider.html)
 
 アプリケーションコンテキスト内の値を型安全な方法で書き込み/読み取りするためのメソッドを提供します。主に[ミドルウェア](../../how-to/middleware)での使用を想定しています。
 
 ```tsx
 import {
-  unstable_createContext,
-  unstable_RouterContextProvider
+  createContext,
+  RouterContextProvider
 } from "react-router";
 
-const userContext = unstable_createContext<User | null>(null);
-const contextProvider = new unstable_RouterContextProvider();
+const userContext = createContext<User | null>(null);
+const contextProvider = new RouterContextProvider();
 contextProvider.set(userContext, getUser());
 //                               ^ Type-safe
 const user = contextProvider.get(userContext);

--- a/docs/react-router-v7/api/utils/createContext.md
+++ b/docs/react-router-v7/api/utils/createContext.md
@@ -1,9 +1,8 @@
 ---
 title: createContext
-unstable: true
 ---
 
-# unstable_createContext
+# createContext
 
 <!--
 ⚠️ ⚠️ IMPORTANT ⚠️ ⚠️ 
@@ -19,25 +18,20 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 [MODES: framework, data]
 
-<br />
-<br />
-
-<docs-warning>このAPIは実験的なものであり、マイナー/パッチリリースで破壊的な変更が行われる可能性があります。注意して使用し、関連する変更についてはリリースノートに**細心の**注意を払ってください。</docs-warning>
-
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.unstable_createContext.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.createContext.html)
 
-型安全な[`unstable_RouterContext`](https://api.reactrouter.com/v7/interfaces/react_router.unstable_RouterContext.html)オブジェクトを作成します。これは、[`action`](../../start/framework/route-module#action)s、[`loader`](../../start/framework/route-module#loader)s、および[ミドルウェア](../../how-to/middleware)で任意の値を保存および取得するために使用できます。Reactの[`createContext`](https://react.dev/reference/react/createContext)に似ていますが、React Routerのリクエスト/レスポンスライフサイクル向けに特別に設計されています。
+型安全な[`RouterContext`](https://api.reactrouter.com/v7/interfaces/react_router.RouterContext.html)オブジェクトを作成します。これは、[`action`](../../start/framework/route-module#action)s、[`loader`](../../start/framework/route-module#loader)s、および[ミドルウェア](../../how-to/middleware)で任意の値を保存および取得するために使用できます。Reactの[`createContext`](https://react.dev/reference/react/createContext)に似ていますが、React Routerのリクエスト/レスポンスライフサイクル向けに特別に設計されています。
 
 `defaultValue`が提供された場合、コンテキストに値が設定されていないときに`context.get()`からその値が返されます。それ以外の場合、値が設定されていないときにこのコンテキストを読み取るとエラーがスローされます。
 
 ```tsx filename=app/context.ts
-import { unstable_createContext } from "react-router";
+import { createContext } from "react-router";
 
 // Create a context for user data
 export const userContext =
-  unstable_createContext<User | null>(null);
+  createContext<User | null>(null);
 ```
 
 ```tsx filename=app/middleware/auth.ts
@@ -72,9 +66,7 @@ export async function loader({
 ## Signature
 
 ```tsx
-function unstable_createContext<T>(
-  defaultValue?: T,
-): unstable_RouterContext<T>
+function createContext<T>(defaultValue?: T): RouterContext<T>
 ```
 
 ## Params
@@ -85,4 +77,4 @@ function unstable_createContext<T>(
 
 ## Returns
 
-[`unstable_RouterContext`](https://api.reactrouter.com/v7/interfaces/react_router.unstable_RouterContext.html)オブジェクトです。これは、[`action`](../../start/framework/route-module#action)s、[`loader`](../../start/framework/route-module#loader)s、および[ミドルウェア](../../how-to/middleware)で`context.get()`および`context.set()`と共に使用できます。
+[`RouterContext`](https://api.reactrouter.com/v7/interfaces/react_router.RouterContext.html)オブジェクトです。これは、[`action`](../../start/framework/route-module#action)s、[`loader`](../../start/framework/route-module#loader)s、および[ミドルウェア](../../how-to/middleware)で`context.get()`および`context.set()`と共に使用できます。

--- a/docs/react-router-v7/api/utils/createRoutesFromElements.md
+++ b/docs/react-router-v7/api/utils/createRoutesFromElements.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/co
 
 ## 概要
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/variables/react_router.createRoutesFromElements.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/functions/react_router.createRoutesFromElements.html)
 
 オブジェクトの配列の代わりに、JSX要素からルートオブジェクトを作成します。
 

--- a/docs/react-router-v7/api/utils/redirect.md
+++ b/docs/react-router-v7/api/utils/redirect.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## 概要
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/variables/react_router.redirect.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/functions/react_router.redirect.html)
 
 リダイレクト [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) です。ステータスコードと [`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location) ヘッダーを設定します。デフォルトは [`302 Found`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) です。
 

--- a/docs/react-router-v7/api/utils/redirectDocument.md
+++ b/docs/react-router-v7/api/utils/redirectDocument.md
@@ -4,11 +4,23 @@ title: redirectDocument
 
 # redirectDocument
 
+<!--
+⚠️ ⚠️ IMPORTANT ⚠️ ⚠️
+
+Thank you for helping improve our documentation!
+
+This file is auto-generated from the JSDoc comments in the source
+code, so please edit the JSDoc comments in the file below and this
+file will be re-generated once those changes are merged.
+
+https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/router/utils.ts
+-->
+
 [MODES: framework, data]
 
 ## 概要
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/variables/react_router.redirectDocument.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/functions/react_router.redirectDocument.html)
 
 新しい場所へのドキュメントのリロードを強制するリダイレクト[`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)です。ステータスコードと[`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location)ヘッダーを設定します。デフォルトは[`302 Found`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302)です。
 

--- a/docs/react-router-v7/api/utils/replace.md
+++ b/docs/react-router-v7/api/utils/replace.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## 概要
 
-[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/variables/react_router.replace.html)
+[リファレンスドキュメント ↗](https://api.reactrouter.com/v7/functions/react_router.replace.html)
 
 クライアントサイドのナビゲーションリダイレクトで、[`history.pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) の代わりに [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) を実行するリダイレクト [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) です。
 ステータスコードと [`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location) ヘッダーを設定します。

--- a/docs/react-router-v7/community/api-development-strategy.md
+++ b/docs/react-router-v7/community/api-development-strategy.md
@@ -6,7 +6,7 @@ title: API 開発戦略
 
 React Router はアプリケーションの基盤です。React エコシステムが進歩するにつれて、動作や API を調整および強化できるようにしながら、新しいメジャーバージョンへのアップグレードが可能な限りスムーズになるようにしたいと考えています。
 
-私たちの戦略と動機については、[Future Flags][future-flags-blog-post] のブログ記事で詳しく説明しています。
+私たちの戦略と動機については、[Future Flags][future-flags-blog-post] のブログ記事と私たちの [Open Governance Model][governance] で詳しく説明されています。
 
 ## Future Flags
 
@@ -36,11 +36,9 @@ Unstable Flags は実験的なものであり、存続が保証されていな�
 
 ### 新機能のフローの例
 
-新機能の決定フローは次のようになります（この図は Remix v1/v2 に関連していますが、React Router v6/v7 にも適用されることに注意してください）。
+新機能の決定フローは次のようになります。
 
-![新機能を導入する方法の決定プロセスのフローチャート][feature-flowchart]
+<img width="400" src="https://reactrouter.com/_docs/feature-flowchart.png" alt="Flowchart of the decision process for how to introduce a new feature" />
 
 [future-flags-blog-post]: https://remix.run/blog/future-flags
-[feature-flowchart]: https://remix.run/docs-images/feature-flowchart.png
-[picking-a-router]: ../routers/picking-a-router
-
+[governance]: https://github.com/remix-run/react-router/blob/main/GOVERNANCE.md#new-feature-process

--- a/docs/react-router-v7/how-to/middleware.md
+++ b/docs/react-router-v7/how-to/middleware.md
@@ -1,6 +1,5 @@
 ---
 title: ミドルウェア
-unstable: true
 ---
 
 # ミドルウェア
@@ -10,7 +9,7 @@ unstable: true
 <br/>
 <br/>
 
-<docs-warning>ミドルウェア機能は現在実験段階であり、破壊的変更の可能性があります。有効にするには、`future.unstable_middleware`フラグを使用してください。</docs-warning>
+<docs-info>フレームワークモードでは、`getLoadContext`関数と`loader`/`action`の`context`パラメーターに軽微な[破壊的変更][getloadcontext]が含まれているため、[`future.v8_middleware`][future-flags]フラグを介してミドルウェアをオプトインする必要があります。</docs-info>
 
 ミドルウェアを使用すると、一致したパスの[`Response`][Response]生成の前後にコードを実行できます。これにより、認証、ロギング、エラー処理、データ前処理などの[一般的なパターン][common-patterns]を再利用可能な方法で実現できます。
 
@@ -41,24 +40,23 @@ import type { Config } from "@react-router/dev/config";
 
 export default {
   future: {
-    unstable_middleware: true,
+    v8_middleware: true,
   },
 } satisfies Config;
 ```
 
-<docs-warning>ミドルウェア機能を有効にすると、`action`と`loader`の`context`パラメーターの型が変更されます。現在`context`を積極的に使用している場合は、以下の[`getLoadContext`][getloadcontext]セクションに注意してください。</docs-warning>
+<docs-warning>ミドルウェア機能を有効にすると、[`action`][framework-action]と[`loader`][framework-loader]の`context`パラメーターの型が変更されます。現在`context`を積極的に使用している場合は、以下の[`getLoadContext`][getloadcontext]セクションに注意してください。</docs-warning>
 
 ### 2. コンテキストを作成する
 
 ミドルウェアは、ミドルウェアチェーンにデータを供給するために`context`プロバイダーインスタンスを使用します。
-[`unstable_createContext`][createContext]を使用して型安全なコンテキストオブジェクトを作成できます。
+[`createContext`][createContext]を使用して型安全なコンテキストオブジェクトを作成できます。
 
 ```ts filename=app/context.ts
-import { unstable_createContext } from "react-router";
+import { createContext } from "react-router";
 import type { User } from "~/types";
 
-export const userContext =
-  unstable_createContext<User | null>(null);
+export const userContext = createContext<User | null>(null);
 ```
 
 ### 3. ルートからミドルウェアをエクスポートする
@@ -76,8 +74,9 @@ async function authMiddleware({ request, context }) {
   context.set(userContext, user);
 }
 
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [authMiddleware];
+export const middleware: Route.MiddlewareFunction[] = [
+  authMiddleware,
+];
 
 // クライアントサイドタイミングミドルウェア
 async function timingMiddleware({ context }, next) {
@@ -87,7 +86,7 @@ async function timingMiddleware({ context }, next) {
   console.log(`Navigation took ${duration}ms`);
 }
 
-export const unstable_clientMiddleware: Route.unstable_ClientMiddlewareFunction[] =
+export const clientMiddleware: Route.ClientMiddlewareFunction[] =
   [timingMiddleware];
 
 export async function loader({
@@ -112,20 +111,20 @@ export default function Dashboard({
 
 ### 4. `getLoadContext`関数を更新する（該当する場合）
 
-カスタムサーバーと`getLoadContext`関数を使用している場合、実装を更新して、JavaScriptオブジェクトの代わりに[`unstable_RouterContextProvider`][RouterContextProvider]のインスタンスを返す必要があります。
+カスタムサーバーと`getLoadContext`関数を使用している場合、実装を更新して、JavaScriptオブジェクトの代わりに[`RouterContextProvider`][RouterContextProvider]のインスタンスを返す必要があります。
 
 ```diff
 +import {
-+  unstable_createContext,
-+  unstable_RouterContextProvider,
++  createContext,
++  RouterContextProvider,
 +} from "react-router";
 import { createDb } from "./db";
 
-+const dbContext = unstable_createContext<Database>();
++const dbContext = createContext<Database>();
 
 function getLoadContext(req, res) {
 -  return { db: createDb() };
-+  const context = new unstable_RouterContextProvider();
++  const context = new RouterContextProvider();
 +  context.set(dbContext, createDb());
 +  return context;
 }
@@ -138,14 +137,13 @@ function getLoadContext(req, res) {
 ### 1. コンテキストを作成する
 
 ミドルウェアは、ミドルウェアチェーンにデータを供給するために`context`プロバイダーインスタンスを使用します。
-[`unstable_createContext`][createContext]を使用して型安全なコンテキストオブジェクトを作成できます。
+[`createContext`][createContext]を使用して型安全なコンテキストオブジェクトを作成できます。
 
 ```ts
-import { unstable_createContext } from "react-router";
+import { createContext } from "react-router";
 import type { User } from "~/types";
 
-export const userContext =
-  unstable_createContext<User | null>(null);
+export const userContext = createContext<User | null>(null);
 ```
 
 ### 2. ルートにミドルウェアを追加する
@@ -157,12 +155,12 @@ import { userContext } from "~/context";
 const routes = [
   {
     path: "/",
-    unstable_middleware: [timingMiddleware], // 👈
+    middleware: [timingMiddleware], // 👈
     Component: Root,
     children: [
       {
         path: "profile",
-        unstable_middleware: [authMiddleware], // 👈
+        middleware: [authMiddleware], // 👈
         loader: profileLoader,
         Component: Profile,
       },
@@ -208,23 +206,23 @@ export default function Profile() {
 }
 ```
 
-### 3. `unstable_getContext`関数を追加する（オプション）
+### 3. `getContext`関数を追加する（オプション）
 
-すべてのナビゲーション/フェッチにベースコンテキストを含めたい場合は、ルーターに[`unstable_getContext`][getContext]関数を追加できます。これは、すべてのナビゲーション/フェッチで新しいコンテキストを生成するために呼び出されます。
+すべてのナビゲーション/フェッチにベースコンテキストを含めたい場合は、ルーターに[`getContext`][getContext]関数を追加できます。これは、すべてのナビゲーション/フェッチで新しいコンテキストを生成するために呼び出されます。
 
 ```tsx
-let sessionContext = unstable_createContext();
+let sessionContext = createContext();
 
 const router = createBrowserRouter(routes, {
-  unstable_getContext() {
-    let context = new unstable_RouterContextProvider();
+  getContext() {
+    let context = new RouterContextProvider();
     context.set(sessionContext, getSession());
     return context;
   },
 });
 ```
 
-<docs-info>このAPIは、フレームワークモードのサーバーにおける`getLoadContext` APIをミラーリングするために存在します。これは、HTTPサーバーからReact Routerハンドラーに値を渡す方法として存在します。この[`unstable_getContext`][getContext] APIは、[`window`][window]/[`document`][document]からReact Routerにグローバルな値を渡すために使用できますが、これらはすべて同じコンテキスト（ブラウザ）で実行されるため、ルートミドルウェアを使用しても実質的に同じ動作を実現できます。したがって、サーバーと同じ方法でこのAPIが必要ない場合もありますが、一貫性のために提供されています。</docs-info>
+<docs-info>このAPIは、フレームワークモードのサーバーにおける`getLoadContext` APIをミラーリングするために存在します。これは、HTTPサーバーからReact Routerハンドラーに値を渡す方法として存在します。この[`getContext`][getContext] APIは、[`window`][window]/[`document`][document]からReact Routerにグローバルな値を渡すために使用できますが、これらはすべて同じコンテキスト（ブラウザ）で実行されるため、ルートミドルウェアを使用しても実質的に同じ動作を実現できます。したがって、サーバーと同じ方法でこのAPIが必要ない場合もありますが、一貫性のために提供されています。</docs-info>
 
 ## コアコンセプト
 
@@ -241,8 +239,9 @@ async function serverMiddleware({ request }, next) {
 }
 
 // Framework mode only
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [serverMiddleware];
+export const middleware: Route.MiddlewareFunction[] = [
+  serverMiddleware,
+];
 ```
 
 クライアントミドルウェアは、クライアントサイドのナビゲーションとフェッチャー呼び出しのために、フレームワークモードとデータモードのブラウザで実行されます。クライアントミドルウェアは、HTTPリクエストがないため、`Response`をバブルアップしない点でサーバーミドルウェアとは異なります。ほとんどの場合、`next`からの戻り値を無視し、クライアントのミドルウェアから何も返さないことができます。
@@ -255,13 +254,13 @@ async function clientMiddleware({ request }, next) {
 }
 
 // Framework mode
-export const unstable_clientMiddleware: Route.unstable_MiddlewareFunction[] =
+export const clientMiddleware: Route.ClientMiddlewareFunction[] =
   [clientMiddleware];
 
 // Or, Data mode
 const route = {
   path: "/",
-  unstable_middleware: [clientMiddleware],
+  middleware: [clientMiddleware],
   loader: rootLoader,
   Component: Root,
 };
@@ -326,8 +325,9 @@ async function loggingMiddleware({ request }, next) {
   return response;
 }
 
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [loggingMiddleware];
+export const middleware: Route.MiddlewareFunction[] = [
+  loggingMiddleware,
+];
 ```
 
 しかし、`loader`が存在しない場合でも、_すべての_クライアントナビゲーションで特定のサーバーミドルウェアを実行したい場合があります。例えば、サイトの認証済みセクションにあるフォームで、`loader`は必要ないが、ユーザーがフォームに入力する前に認証ミドルウェアを使用してリダイレクトしたい場合などです。`action`に送信するときではなく。ミドルウェアがこれらの基準を満たす場合、そのルートを含むルートに`loader`を配置することで、そのルートが関与するクライアントサイドナビゲーションに対して常にサーバーを呼び出すように強制できます。
@@ -339,8 +339,9 @@ function authMiddleware({ request }, next) {
   }
 }
 
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [authMiddleware];
+export const middleware: Route.MiddlewareFunction[] = [
+  authMiddleware,
+];
 
 // By adding a `loader`, we force the `authMiddleware` to run on every
 // client-side navigation involving this route.
@@ -359,8 +360,8 @@ export async function loader() {
 
 ```ts
 // ✅ 型安全
-import { unstable_createContext } from "react-router";
-const userContext = unstable_createContext<User>();
+import { createContext } from "react-router";
+const userContext = createContext<User>();
 
 // 後でミドルウェア/`loader`s
 context.set(userContext, user); // User型である必要があります
@@ -401,15 +402,14 @@ export function getUser() {
 ```tsx filename=app/root.tsx
 import { provideUser } from "./user-context";
 
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [
-    async ({ request, context }, next) => {
-      return provideUser(request, async () => {
-        let res = await next();
-        return res;
-      });
-    },
-  ];
+export const middleware: Route.MiddlewareFunction[] = [
+  async ({ request, context }, next) => {
+    return provideUser(request, async () => {
+      let res = await next();
+      return res;
+    });
+  },
+];
 ```
 
 ```tsx filename=app/routes/_index.tsx
@@ -466,27 +466,25 @@ React Routerには、ルートの[`ErrorBoundary`][ErrorBoundary]エクスポー
 この動作は、ルート`middleware`から送信されるレスポンスに必須ヘッダーを自動的に設定する（つまり、セッションをコミットする）などのミドルウェアパターンを可能にするために重要です。もし`middleware`からのエラーが`next()`を`throw`させた場合、終了時の祖先ミドルウェアの実行を見逃し、必要なヘッダーが設定されなくなります。
 
 ```tsx filename=routes/parent.tsx
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [
-    async (_, next) => {
-      let res = await next();
-      //  ^ res.status = 500
-      // This response contains the ErrorBoundary
-      return res;
-    },
-  ];
+export const middleware: Route.MiddlewareFunction[] = [
+  async (_, next) => {
+    let res = await next();
+    //  ^ res.status = 500
+    // This response contains the ErrorBoundary
+    return res;
+  },
+];
 ```
 
 ```tsx filename=routes/parent.child.tsx
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [
-    async (_, next) => {
-      let res = await next();
-      //  ^ res.status = 200
-      // This response contains the successful UI render
-      throw new Error("Uh oh, something went wrong!");
-    },
-  ];
+export const middleware: Route.MiddlewareFunction[] = [
+  async (_, next) => {
+    let res = await next();
+    //  ^ res.status = 200
+    // This response contains the successful UI render
+    throw new Error("Uh oh, something went wrong!");
+  },
+];
 ```
 
 ## `getLoadContext`/`AppLoadContext`の変更点
@@ -497,31 +495,31 @@ export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
 
 ミドルウェアは`clientMiddleware`のためにクライアント上で同等の`context`を必要としますが、すでに不満があったサーバーからのこのパターンを複製したくなかったため、型安全に取り組める新しいAPIを導入することにしました。
 
-ミドルウェアをオプトインすると、`context`パラメーターは[`unstable_RouterContextProvider`][RouterContextProvider]のインスタンスに変更されます。
+ミドルウェアをオプトインすると、`context`パラメーターは[`RouterContextProvider`][RouterContextProvider]のインスタンスに変更されます。
 
 ```ts
-let dbContext = unstable_createContext<Database>();
-let context = new unstable_RouterContextProvider();
+let dbContext = createContext<Database>();
+let context = new RouterContextProvider();
 context.set(dbContext, getDb());
 //                     ^ type-safe
 let db = context.get(dbContext);
 //  ^ Database
 ```
 
-カスタムサーバーと`getLoadContext`関数を使用している場合、実装を更新して、プレーンなJavaScriptオブジェクトの代わりに[`unstable_RouterContextProvider`][RouterContextProvider]のインスタンスを返す必要があります。
+カスタムサーバーと`getLoadContext`関数を使用している場合、実装を更新して、プレーンなJavaScriptオブジェクトの代わりに[`RouterContextProvider`][RouterContextProvider]のインスタンスを返す必要があります。
 
 ```diff
 +import {
-+  unstable_createContext,
-+  unstable_RouterContextProvider,
++  createContext,
++  RouterContextProvider,
 +} from "react-router";
 import { createDb } from "./db";
 
-+const dbContext = unstable_createContext<Database>();
++const dbContext = createContext<Database>();
 
 function getLoadContext(req, res) {
 -  return { db: createDb() };
-+  const context = new unstable_RouterContextProvider();
++  const context = new RouterContextProvider();
 +  context.set(dbContext, createDb());
 +  return context;
 }
@@ -529,12 +527,12 @@ function getLoadContext(req, res) {
 
 ### `AppLoadContext`からの移行
 
-現在`AppLoadContext`を使用している場合、既存のモジュール拡張を使用して`AppLoadContext`の代わりに[`unstable_RouterContextProvider`][RouterContextProvider]を拡張することで、段階的に移行できます。次に、`getLoadContext`関数を更新して、[`unstable_RouterContextProvider`][RouterContextProvider]のインスタンスを返すようにします。
+現在`AppLoadContext`を使用している場合、既存のモジュール拡張を使用して`AppLoadContext`の代わりに[`RouterContextProvider`][RouterContextProvider]を拡張することで、段階的に移行できます。次に、`getLoadContext`関数を更新して、[`RouterContextProvider`][RouterContextProvider]のインスタンスを返すようにします。
 
 ```diff
 declare module "react-router" {
 -  interface AppLoadContext {
-+  interface unstable_RouterContextProvider {
++  interface RouterContextProvider {
     db: Database;
     user: User;
   }
@@ -543,7 +541,7 @@ declare module "react-router" {
 function getLoadContext() {
   const loadContext = {...};
 -  return loadContext;
-+  let context = new unstable_RouterContextProvider();
++  let context = new RouterContextProvider();
 +  Object.assign(context, loadContext);
 +  return context;
 }
@@ -553,7 +551,7 @@ function getLoadContext() {
 
 <docs-warning>このアプローチは、React Router v7でミドルウェアを導入する際の移行戦略としてのみ意図されており、`context.set`/`context.get`への段階的な移行を可能にします。このアプローチがReact Routerの次のメジャーバージョンで機能すると仮定するのは安全ではありません。</docs-warning>
 
-<docs-warning>[`unstable_RouterContextProvider`][RouterContextProvider]クラスは、`<HydratedRouter unstable_getContext>`および`<RouterProvider unstable_getContext>`を介したクライアントサイドの`context`パラメーターにも使用されます。`AppLoadContext`は主にHTTPサーバーからReact Routerハンドラーへの引き渡しとして意図されているため、これらの拡張フィールドは`clientMiddleware`、`clientLoader`、または`clientAction`関数では利用できないことに注意する必要があります（もちろん、クライアントで`unstable_getContext`を介してフィールドを提供しない限り、TypeScriptはそれらが利用可能であると示しますが）。</docs-warning>
+<docs-warning>[`RouterContextProvider`][RouterContextProvider]クラスは、`<HydratedRouter getContext>`および`<RouterProvider getContext>`を介したクライアントサイドの`context`パラメーターにも使用されます。`AppLoadContext`は主にHTTPサーバーからReact Routerハンドラーへの引き渡しとして意図されているため、これらの拡張フィールドは`clientMiddleware`、`clientLoader`、または`clientAction`関数では利用できないことに注意する必要があります（もちろん、クライアントで`getContext`を介してフィールドを提供しない限り、TypeScriptはそれらが利用可能であると示しますが）。</docs-warning>
 
 ## 一般的なパターン
 
@@ -583,8 +581,9 @@ export const authMiddleware = async ({
 ```tsx filename=app/routes/protected.tsx
 import { authMiddleware } from "~/middleware/auth";
 
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [authMiddleware];
+export const middleware: Route.MiddlewareFunction[] = [
+  authMiddleware,
+];
 
 export async function loader({
   context,
@@ -666,36 +665,34 @@ export const headersMiddleware = async (
 ### 条件付きミドルウェア
 
 ```tsx
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [
-    async ({ request, context }, next) => {
-      // POSTリクエストの場合のみ認証を実行
-      if (request.method === "POST") {
-        await ensureAuthenticated(request, context);
-      }
-      return next();
-    },
-  ];
+export const middleware: Route.MiddlewareFunction[] = [
+  async ({ request, context }, next) => {
+    // POSTリクエストの場合のみ認証を実行
+    if (request.method === "POST") {
+      await ensureAuthenticated(request, context);
+    }
+    return next();
+  },
+];
 ```
 
 ### `action`と`loader`間でのコンテキスト共有
 
 ```tsx
-const sharedDataContext = unstable_createContext<any>();
+const sharedDataContext = createContext<any>();
 
-export const unstable_middleware: Route.unstable_MiddlewareFunction[] =
-  [
-    async ({ request, context }, next) => {
-      if (request.method === "POST") {
-        // アクションフェーズ中にデータを設定
-        context.set(
-          sharedDataContext,
-          await getExpensiveData(),
-        );
-      }
-      return next();
-    },
-  ];
+export const middleware: Route.MiddlewareFunction[] = [
+  async ({ request, context }, next) => {
+    if (request.method === "POST") {
+      // アクションフェーズ中にデータを設定
+      context.set(
+        sharedDataContext,
+        await getExpensiveData(),
+      );
+    }
+    return next();
+  },
+];
 
 export async function action({
   context,
@@ -712,6 +709,7 @@ export async function loader({
 }
 ```
 
+[future-flags]: ../upgrading/future
 [Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [common-patterns]: #common-patterns
 [server-client]: #server-vs-client-middleware
@@ -723,7 +721,7 @@ export async function loader({
 [cms-redirect]: #cms-redirect-on-404
 [createContext]: ../api/utils/createContext
 [RouterContextProvider]: ../api/utils/RouterContextProvider
-[getContext]: ../api/data-routers/createBrowserRouter#optsunstable_getContext
+[getContext]: ../api/data-routers/createBrowserRouter#optsgetContext
 [window]: https://developer.mozilla.org/en-US/docs/Web/API/Window
 [document]: https://developer.mozilla.org/en-US/docs/Web/API/Document
 [request]: https://developer.mozilla.org/en-US/docs/Web/API/Request

--- a/docs/react-router-v7/index.md
+++ b/docs/react-router-v7/index.md
@@ -12,7 +12,7 @@ React Router は、React 18 から React 19 へのギャップを埋める、Rea
 アプリで使用する方法（または「モード」）は主に3つあるため、始めるためのガイドも3つあります。
 
 - [宣言的](./start/declarative/installation)
-- [データ](./start/data/custom)
+- [データ](./start/data/installation)
 - [フレームワーク](./start/framework/installation)
 
 どのモードが自分に適しているかは、[モードの選択](./start/modes)で確認してください。
@@ -37,4 +37,3 @@ React Router は、React 18 から React 19 へのギャップを埋める、Rea
 
 - [v6 からのアップグレード](./upgrading/v6)
 - [Remix からのアップグレード](./upgrading/remix)
-

--- a/docs/react-router-v7/start/data/route-object.md
+++ b/docs/react-router-v7/start/data/route-object.md
@@ -54,7 +54,7 @@ function MyRouteComponent() {
 }
 ```
 
-## `unstable_middleware`
+## `middleware`
 
 ルート[ミドルウェア][middleware]は、ナビゲーションの前後に順次実行されます。これにより、ロギングや認証などの処理を一箇所で行うことができます。`next` 関数はチェーンを続行し、リーフルートでは `next` 関数がナビゲーションのローダー/アクションを実行します。
 
@@ -62,12 +62,12 @@ function MyRouteComponent() {
 createBrowserRouter([
   {
     path: "/",
-    unstable_middleware: [loggingMiddleware],
+    middleware: [loggingMiddleware],
     loader: rootLoader,
     Component: Root,
     children: [{
       path: 'auth',
-      unstable_middleware: [authMiddleware],
+      middleware: [authMiddleware],
       loader: authLoader,
       Component: Auth,
       children: [...]
@@ -84,7 +84,7 @@ async function loggingMiddleware({ request }, next) {
   console.log(`Navigation completed in ${duration}ms`);
 }
 
-const userContext = unstable_createContext<User>();
+const userContext = createContext<User>();
 
 async function authMiddleware ({ context }) {
   const userId = getUserId();

--- a/docs/react-router-v7/start/framework/route-module.md
+++ b/docs/react-router-v7/start/framework/route-module.md
@@ -78,7 +78,7 @@ export default function MyRouteComponent({
 }
 ```
 
-## `unstable_middleware`
+## `middleware`
 
 ルート[ミドルウェア][middleware]は、ドキュメントおよびデータリクエストの前後でサーバー上で順次実行されます。これにより、ロギング、認証、レスポンスの後処理などを一箇所で行うことができます。`next` 関数はチェーンを続行し、リーフルートでは `next` 関数がナビゲーションのローダー/アクションを実行します。
 
@@ -101,7 +101,7 @@ async function loggingMiddleware(
   return response;
 }
 
-export const unstable_middleware = [loggingMiddleware];
+export const middleware = [loggingMiddleware];
 ```
 
 以下は、ログインしているユーザーをチェックし、ローダーからアクセスできる `context` にユーザーを設定するミドルウェアの例です。
@@ -122,19 +122,19 @@ async function authMiddleware ({
   context.set(userContext, user);
 };
 
-export const unstable_middleware = [authMiddleware];
+export const middleware = [authMiddleware];
 ```
 
 <docs-warning>ルートにミドルウェアを追加する際に、アプリケーションが意図したとおりに動作するように、[ミドルウェアがいつ実行されるか][when-middleware-runs]を理解していることを確認してください。</docs-warning>
 
 参照：
 
-- [`unstable_middleware` params][middleware-params]
+- [`middleware` params][middleware-params]
 - [ミドルウェア][middleware]
 
-## `unstable_clientMiddleware`
+## `clientMiddleware`
 
-これは `unstable_middleware` のクライアントサイド版であり、クライアントナビゲーション中にブラウザで実行されます。サーバーミドルウェアとの唯一の違いは、クライアントミドルウェアはサーバー上のHTTPリクエストをラップしないため、レスポンスを返さないことです。
+これは `middleware` のクライアントサイド版であり、クライアントナビゲーション中にブラウザで実行されます。サーバーミドルウェアとの唯一の違いは、クライアントミドルウェアはサーバー上のHTTPリクエストをラップしないため、レスポンスを返さないことです。
 
 以下は、クライアント上でリクエストをログに記録するミドルウェアの例です。
 
@@ -155,7 +155,7 @@ async function loggingMiddleware(
   // ✅ No need to return anything
 }
 
-export const unstable_clientMiddleware = [
+export const clientMiddleware = [
   loggingMiddleware,
 ];
 ```
@@ -479,7 +479,7 @@ export default function Root() {
 
 ## `shouldRevalidate`
 
-フレームワークモードでは、ルートローダーはすべてのナビゲーションとフォーム送信後に自動的に再検証されます（これは[データモード](../data/route-object#shouldrevalidate)とは異なります）。これにより、ミドルウェアとローダーはリクエストコンテキストを共有し、データモードの場合とは異なる方法で最適化できます。
+SSR を使用するフレームワークモードでは、ルートローダーはすべてのナビゲーションとフォーム送信後に自動的に再検証されます（これは[データモード][data-mode-should-revalidate]とは異なります）。これにより、ミドルウェアとローダーはリクエストコンテキストを共有し、データモードの場合とは異なる方法で最適化できます。
 
 この関数を定義すると、ナビゲーションとフォーム送信に対するルートローダーの再検証をオプトアウトできます。
 
@@ -493,13 +493,15 @@ export function shouldRevalidate(
 }
 ```
 
+[SPA モード][spa-mode]を使用する場合、ナビゲーション時に呼び出すサーバーローダーがないため、`shouldRevalidate` は[データモード][data-mode-should-revalidate]と同じように動作します。
+
 [`ShouldRevalidateFunctionArgs` Reference Documentation ↗](https://api.reactrouter.com/v7/interfaces/react_router.ShouldRevalidateFunctionArgs.html)
 
 ---
 
 次: [レンダリング戦略](./rendering)
 
-[middleware-params]: https://api.reactrouter.com/v7/types/react_router.unstable_MiddlewareFunction.html
+[middleware-params]: https://api.reactrouter.com/v7/types/react_router.MiddlewareFunction.html
 [middleware]: ../../how-to/middleware
 [when-middleware-runs]: ../../how-to/middleware#when-middleware-runs
 [loader-params]: https://api.reactrouter.com/v7/interfaces/react_router.LoaderFunctionArgs
@@ -514,3 +516,5 @@ export function shouldRevalidate(
 [meta-element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 [meta-params]: https://api.reactrouter.com/v7/interfaces/react_router.MetaArgs
 [meta-function]: https://api.reactrouter.com/v7/types/react_router.MetaDescriptor.html
+[data-mode-should-revalidate]: ../data/route-object#shouldrevalidate
+[spa-mode]: ../../how-to/spa

--- a/docs/react-router-v7/start/framework/routing.md
+++ b/docs/react-router-v7/start/framework/routing.md
@@ -230,6 +230,24 @@ export default [
 ] satisfies RouteConfig;
 ```
 
+これはルートツリーに新しいルートを導入するものではないことに注意してください。代わりに、子ルートのパスを単に修正するだけです。
+
+例えば、以下の2つのルートのセットは同等です。
+
+```ts filename=app/routes.ts
+// この `prefix` の使用法は...
+prefix("parent", [
+  route("child1", "./child1.tsx"),
+  route("child2", "./child2.tsx"),
+])
+
+// ...以下と同等です:
+[
+  route("parent/child1", "./child1.tsx"),
+  route("parent/child2", "./child2.tsx"),
+]
+```
+
 ## 動的セグメント
 
 パスセグメントが `:` で始まる場合、それは「動的セグメント」になります。ルートが URL と一致すると、動的セグメントは URL から解析され、他のルーター API に `params` として提供されます。

--- a/docs/react-router-v7/start/modes.md
+++ b/docs/react-router-v7/start/modes.md
@@ -74,7 +74,7 @@ export default [
 これにより、型安全なパラメータ、loaderData、コード分割、SPA/SSR/SSG戦略などを備えたRoute Module APIにアクセスできるようになります。
 
 ```ts filename=product.tsx
-import { Route } from "+./types/product.tsx";
+import { Route } from "./+types/product.tsx";
 
 export async function loader({ params }: Route.LoaderArgs) {
   let product = await getProduct(params.pid);
@@ -146,7 +146,7 @@ export default function Product({
 | Scripts                        | ✅        |      |             |
 | ScrollRestoration              | ✅        | ✅   |             |
 | ServerRouter                   | ✅        |      |             |
-| usePrompt                      | ✅        | ✅   | ✅          |
+| usePrompt                      | ✅        | ✅   |             |
 | useActionData                  | ✅        | ✅   |             |
 | useAsyncError                  | ✅        | ✅   |             |
 | useAsyncValue                  | ✅        | ✅   |             |

--- a/docs/react-router-v7/upgrading/future.md
+++ b/docs/react-router-v7/upgrading/future.md
@@ -1,5 +1,6 @@
 ---
 title: 将来のフラグ
+order: 1
 ---
 
 # 将来のフラグと非推奨
@@ -8,4 +9,43 @@ title: 将来のフラグ
 
 各ステップの後にコミットを作成して出荷することを強くお勧めします。ほとんどのフラグは任意の順序で採用できますが、例外は下記に記載されています。
 
-<docs-warning>**React Router v7 には現在、将来のフラグはありません**</docs-warning>
+## 最新の v7.x への更新
+
+まず、最新の将来のフラグを利用するために、v7.x の最新のマイナーバージョンに更新してください。アップグレード時にいくつかの非推奨警告が表示されるかもしれませんが、それについては後述します。
+
+👉 最新の v7 に更新
+
+```sh
+npm install react-router@7 @react-router/{dev,node,etc.}@7
+```
+
+## `future.v8_middleware`
+
+[MODES: framework]
+
+<br/>
+<br/>
+
+**背景**
+
+Middleware を使用すると、一致したパスの [`Response`][Response] 生成の前後にコードを実行できます。これにより、認証、ロギング、エラー処理、データ前処理などの一般的なパターンを再利用可能な方法で実現できます。詳細については、[ドキュメント](../how-to/middleware)を参照してください。
+
+👉 **フラグを有効にする**
+
+```ts filename=react-router.config.ts
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  future: {
+    v8_middleware: true,
+  },
+} satisfies Config;
+```
+
+**コードの更新**
+
+`react-router-serve` を使用している場合、コードを更新する必要はありません。
+
+`loader` および `action` 関数で `context` パラメータを使用している場合にのみ、コードを更新する必要があります。これは、`getLoadContext` 関数を持つカスタムサーバーを使用している場合にのみ適用されます。middleware の [`getLoadContext` の変更点](../how-to/middleware#changes-to-getloadcontextapploadcontext)に関するドキュメントと、[新しい API への移行手順](../how-to/middleware#migration-from-apploadcontext)を参照してください。
+
+[Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response


### PR DESCRIPTION


v7のミドルウェアAPIを安定させ、`unstable_`プレフィックスを削除し、`future.v8_middleware`フラグを導入します。

この変更に伴い、ドキュメント全体で以下の更新を行いました。

- `unstable_middleware` -> `middleware`
- `unstable_clientMiddleware` -> `clientMiddleware`
- `unstable_RouterContextProvider` -> `RouterContextProvider`
- `unstable_createContext` -> `createContext`
- `unstable_getContext` -> `getContext`
- `unstable: true` のfrontmatterと関連する警告を削除
- 新しい `v8_middleware` futureフラグを説明するための `upgrading/future.md` ページを追加
- APIリファレンスドキュメントへの多数のリンクを更新
- その他、軽微な修正と改善を実施